### PR TITLE
Configure Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    labels:
+      - ":robot: dependabot"
+      - ":octocat: github-actions"
+      - ":heavy_plus_sign: dependencies"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    labels:
+      - ":robot: dependabot"
+      - ":package: npm"
+      - ":heavy_plus_sign: dependencies"


### PR DESCRIPTION
## Summary

This PR configures Dependabot to automatically manage dependency updates for this repository, following the patterns established in the `granthub` repository.

## Changes

- **Added `.github/dependabot.yml`** with configuration for:
  - **npm ecosystem**: Monitors all 25+ devDependencies and peerDependencies in `package.json`
  - **GitHub Actions ecosystem**: Monitors workflow files for action updates (e.g., `actions/checkout`, `actions/setup-node`)

## Configuration Details

### Schedule
- **Weekly updates on Wednesdays** - aligns with organizational patterns

### Pull Request Limits
- **npm**: Default limit of 5 concurrent version update PRs
- **Security updates**: Separate internal limit of 10 PRs (automatic)

### Labels
All Dependabot PRs will be automatically tagged with emoji labels for easy filtering:
- `:robot: dependabot`
- `:package: npm` or `:octocat: github-actions`
- `:heavy_plus_sign: dependencies`

## Benefits

✅ **Automated dependency updates** - No more manual version bumps
✅ **Security patches** - Automatic PRs for vulnerabilities with separate priority
✅ **Consistent tooling** - Matches the Dependabot configuration in granthub
✅ **Better organization** - Emoji labels make it easy to filter and manage dependency PRs
✅ **Controlled updates** - Weekly schedule prevents notification overload

## Testing

Once merged, Dependabot will:
1. Automatically detect the configuration file
2. Begin monitoring dependencies
3. Create the first batch of PRs next Wednesday (or can be manually triggered from GitHub's Dependency graph)

## Notes

- This repository already has a history of Dependabot updates (visible in commit history)
- The configuration re-enables automated dependency management
- Compatible with Yarn 4 (used by this repository)