### PR TITLE
security: Fix high-severity ansi-regex ReDoS vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,10 @@
     "@rails/request.js": "^0.0.8",
     "sortablejs": "^1.15.0"
   },
-  "packageManager": "yarn@4.12.0"
+  "packageManager": "yarn@4.12.0",
+  "resolutions": {
+    "ansi-regex@^3.0.0": "3.0.1",
+    "ansi-regex@^4.1.0": "4.1.1",
+    "ansi-regex@^5.0.0": "5.0.1"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2705,38 +2705,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:3.0.1":
+  version: 3.0.1
+  resolution: "ansi-regex@npm:3.0.1"
+  checksum: 10c0/d108a7498b8568caf4a46eea4f1784ab4e0dfb2e3f3938c697dee21443d622d765c958f2b7e2b9f6b9e55e2e2af0584eaa9915d51782b89a841c28e744e7a167
+  languageName: node
+  linkType: hard
+
+"ansi-regex@npm:4.1.1":
+  version: 4.1.1
+  resolution: "ansi-regex@npm:4.1.1"
+  checksum: 10c0/d36d34234d077e8770169d980fed7b2f3724bfa2a01da150ccd75ef9707c80e883d27cdf7a0eac2f145ac1d10a785a8a855cffd05b85f778629a0db62e7033da
+  languageName: node
+  linkType: hard
+
+"ansi-regex@npm:5.0.1, ansi-regex@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "ansi-regex@npm:5.0.1"
+  checksum: 10c0/9a64bb8627b434ba9327b60c027742e5d17ac69277960d041898596271d992d4d52ba7267a63ca10232e29f6107fc8a835f6ce8d719b88c5f8493f8254813737
+  languageName: node
+  linkType: hard
+
 "ansi-regex@npm:^2.0.0":
   version: 2.1.1
   resolution: "ansi-regex@npm:2.1.1"
   checksum: 10c0/78cebaf50bce2cb96341a7230adf28d804611da3ce6bf338efa7b72f06cc6ff648e29f80cd95e582617ba58d5fdbec38abfeed3500a98bce8381a9daec7c548b
-  languageName: node
-  linkType: hard
-
-"ansi-regex@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "ansi-regex@npm:3.0.0"
-  checksum: 10c0/c6a2b226d009965decc65d330b953290039f0f2b31d200516a9a79b6010f5f8f9d6acbaa0917d925c578df0c0feaddcb56569aad05776f99e2918116d4233121
-  languageName: node
-  linkType: hard
-
-"ansi-regex@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "ansi-regex@npm:4.1.0"
-  checksum: 10c0/a10376bc12035b0b40f036d3e544d92f9e6a525bc7cd65f71e108c0965d74f777e0eef47a6d0bfbdec1d835df1edf0410516a39525d2d89ce9547eb47644d681
-  languageName: node
-  linkType: hard
-
-"ansi-regex@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "ansi-regex@npm:5.0.0"
-  checksum: 10c0/4c711eeec7ab00c1869e926ae78758abd10137047cbb08b6fda499be2dc39c2d5f21e15c7279dbb222de523b53834b54043d4997191f62372d5e2250edcbc83a
-  languageName: node
-  linkType: hard
-
-"ansi-regex@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "ansi-regex@npm:5.0.1"
-  checksum: 10c0/9a64bb8627b434ba9327b60c027742e5d17ac69277960d041898596271d992d4d52ba7267a63ca10232e29f6107fc8a835f6ce8d719b88c5f8493f8254813737
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes 3 HIGH severity Dependabot alerts by using Yarn resolutions to upgrade vulnerable `ansi-regex` versions to their patched releases.

## Security Alerts Addressed

| Alert # | Package | Vulnerable Version | Patched Version | CVSS Score |
|---------|---------|-------------------|-----------------|------------|
| [#6](https://github.com/instrumentl/stimulus-sortable/security/dependabot/6) | ansi-regex | 3.0.0 | 3.0.1 | 7.5 (HIGH) |
| [#5](https://github.com/instrumentl/stimulus-sortable/security/dependabot/5) | ansi-regex | 4.1.0 | 4.1.1 | 7.5 (HIGH) |
| [#4](https://github.com/instrumentl/stimulus-sortable/security/dependabot/4) | ansi-regex | 5.0.0 | 5.0.1 | 7.5 (HIGH) |

**Vulnerability:** Regular Expression Denial of Service (ReDoS) - [CVE-2021-3807](https://nvd.nist.gov/vuln/detail/CVE-2021-3807)

## Changes Made

### package.json
Added `resolutions` field to force Yarn to use patched versions:

```json
"resolutions": {
  "ansi-regex@^3.0.0": "3.0.1",
  "ansi-regex@^4.1.0": "4.1.1",
  "ansi-regex@^5.0.0": "5.0.1"
}
```

### yarn.lock
Automatically updated by Yarn to reflect the resolved versions.

## Technical Details

### Why This Approach?

- ✅ **Zero breaking changes** - Patch versions only (3.0.0→3.0.1, 4.1.0→4.1.1, 5.0.0→5.0.1)
- ✅ **Backward compatible** - All patched versions maintain CommonJS compatibility
- ✅ **Safe** - Only security fixes, no API changes
- ✅ **Efficient** - Uses Yarn v4 native resolution feature

### Why Not Upgrade to ansi-regex@6.x?

Version 6.x is pure ESM and would break CommonJS compatibility with existing transitive dependencies. The patch versions (3.0.1, 4.1.1, 5.0.1) contain the same security fix backported to CommonJS.

## Risk Assessment

**Risk Level:** Very Low (<1%)

- Development dependencies only (not shipped to production)
- Patch releases with no API changes
- Used by build tools (np, eslint) not runtime code
- Build and lint verified successfully

## Verification

### ✅ Security
```bash
# Confirmed vulnerable versions removed
yarn why ansi-regex
```

All instances now use patched versions (3.0.1, 4.1.1, 5.0.1).

### ✅ Build
```bash
yarn build
# ✓ built in 30ms
# Generated dist/stimulus-sortable.mjs (1.50 kB)
# Generated dist/stimulus-sortable.umd.js (1.61 kB)
```

### ✅ Lint
```bash
yarn lint
# No code-related issues (only pre-existing Prettier warnings on .serena files)
```

## Impact

- **Production:** None (dev dependencies only)
- **Build process:** No changes
- **API:** No changes
- **Dependencies:** Minimal (only ansi-regex patched)

## Next Steps

Once merged, Dependabot will automatically close alerts #4, #5, and #6 after scanning the updated `yarn.lock`.

---

**Closes:** #4, #5, #6
**CVE:** CVE-2021-3807
**Severity:** HIGH (CVSS 7.5)